### PR TITLE
Moving plugin-help to regular dependency instead of dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@oclif/command": "^1.5.19",
     "@oclif/config": "^1.13.3",
     "@oclif/errors": "^1",
+    "@oclif/plugin-help": "^2.2.3",
     "@salesforce/command": "^2.2.0",
     "@salesforce/core": "^2.1.6",
     "@types/fs-extra": "^7.0.0",
@@ -18,7 +19,6 @@
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.22.2",
-    "@oclif/plugin-help": "^2.2.3",
     "@oclif/test": "^1.2.5",
     "@salesforce/dev-config": "1.4.1",
     "@types/chai": "^4.2.8",


### PR DESCRIPTION
Fixes #4 

I think this will fix the dependency warning related to the missing peer.